### PR TITLE
add gpt-tokenizer to comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.2",
     "gpt-3-encoder": "^1.1.4",
+    "gpt-tokenizer": "^2.1.1",
     "gpt3-tokenizer": "^1.1.5",
     "tiktoken-node": "^0.0.5",
     "tinybench": "^2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@dqbd/tiktoken':
@@ -7,6 +11,9 @@ dependencies:
   gpt-3-encoder:
     specifier: ^1.1.4
     version: 1.1.4
+  gpt-tokenizer:
+    specifier: ^2.1.1
+    version: 2.1.1
   gpt3-tokenizer:
     specifier: ^1.1.5
     version: 1.1.5
@@ -1096,6 +1103,12 @@ packages:
     resolution: {integrity: sha512-fSQRePV+HUAhCn7+7HL7lNIXNm6eaFWFbNLOOGtmSJ0qJycyQvj60OvRlH7mee8xAMjBDNRdMXlMwjAbMTDjkg==}
     dev: false
 
+  /gpt-tokenizer@2.1.1:
+    resolution: {integrity: sha512-WlX+vj6aPaZ71U6Bf18fem+5k58zlgh2a4nbc7KHy6aGVIyq3nCh709b/8momu34sV/5t/SpzWi8LayWD9uyDw==}
+    dependencies:
+      rfc4648: 1.5.2
+    dev: false
+
   /gpt3-tokenizer@1.1.5:
     resolution: {integrity: sha512-O9iCL8MqGR0Oe9wTh0YftzIbysypNQmS5a5JG3cB3M4LMYjlAVvNnf8LUzVY9MrI7tj+YLY356uHtO2lLX2HpA==}
     engines: {node: '>=12'}
@@ -1929,6 +1942,10 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
+
+  /rfc4648@1.5.2:
+    resolution: {integrity: sha512-tLOizhR6YGovrEBLatX1sdcuhoSCXddw3mqNVAcKxGJ+J0hFeJ+SjeWCv5UPA/WU3YzWPPuCVYgXBKZUPGpKtg==}
+    dev: false
 
   /rfdc@1.3.0:
     resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}

--- a/src/tokenizers.ts
+++ b/src/tokenizers.ts
@@ -1,4 +1,6 @@
 import * as gpt3Encoder from 'gpt-3-encoder'
+import * as gptTokenizerGpt from 'gpt-tokenizer/esm/model/text-curie-001'
+import * as gptTokenizerDavinci from 'gpt-tokenizer/esm/model/text-davinci-003'
 import { encoding_for_model, get_encoding } from '@dqbd/tiktoken'
 import GPT3TokenizerImport from 'gpt3-tokenizer'
 import TiktokenNode from 'tiktoken-node'
@@ -30,6 +32,16 @@ export const tokenizers: Tokenizer[] = [
     label: 'gpt-3-encoder',
     encode: (i: string) => gpt3Encoder.encode(i),
     decode: (i: number[]) => gpt3Encoder.decode(i)
+  },
+  {
+    label: 'gpt-tokenizer gpt2',
+    encode: (i: string) => gptTokenizerGpt.encode(i),
+    decode: (i: number[]) => gptTokenizerGpt.decode(i)
+  },
+  {
+    label: 'gpt-tokenizer text-davinci-003',
+    encode: (i: string) => gptTokenizerDavinci.encode(i),
+    decode: (i: number[]) => gptTokenizerDavinci.decode(i)
   },
   {
     label: '@dqbd/tiktoken gpt2',


### PR DESCRIPTION
Thanks for the nudge @transitive-bullshit. I've fixed the default import issue you encountered in https://github.com/niieani/gpt-tokenizer/issues/11.

```
┌─────────┬───────────────────────────────────┬───────────────────┬───────────────┐
│ (index) │             Task Name             │ Average Time (ms) │ Variance (ms) │
├─────────┼───────────────────────────────────┼───────────────────┼───────────────┤
│    0    │         'gpt3-tokenizer'          │       33615       │    126310     │
│    1    │          'gpt-3-encoder'          │       19330       │    105469     │
│    2    │       'gpt-tokenizer gpt2'        │       12978       │     1539      │
│    3    │ 'gpt-tokenizer text-davinci-003'  │       12401       │      578      │
│    4    │       '@dqbd/tiktoken gpt2'       │       4411        │     1215      │
│    5    │ '@dqbd/tiktoken text-davinci-003' │       4295        │      69       │
│    6    │       'tiktoken-node gpt2'        │       3822        │      56       │
│    7    │ 'tiktoken-node text-davinci-003'  │       3824        │      57       │
└─────────┴───────────────────────────────────┴───────────────────┴───────────────┘
```